### PR TITLE
Fix two-page PDF export on macOS

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lt
 Type: Package
 Title: Lightweight Tables via JSON Specs and JavaScript
-Version: 0.1.6
+Version: 0.1.7
 Authors@R: person('Yihui', 'Xie', email = 'xie@yihui.name', role = c('aut', 'cre', 'cph'),
     comment = c(ORCID = '0000-0003-0645-5666', URL = 'https://yihui.org'))
 Description: A lightweight grammar of tables. Build a table by declaring a JSON

--- a/R/render.R
+++ b/R/render.R
@@ -320,7 +320,14 @@ lt_measure = function(html, pad, width = NULL, browser = NULL) {
   dom = with_temp_html(html, function(f) xfun::browser_dom(f, browser = browser))
   m = regmatches(dom, regexec('data-ltw="([0-9]+)" data-lth="([0-9]+)"', dom))[[1]]
   if (length(m) != 3L) stop('Failed to measure the table dimensions.')
-  as.integer(m[-1L])
+  d = as.integer(m[-1L])
+  # scrollWidth is the floor of the table's fractional natural width. Pinning
+  # the body to that floored width leaves it a sub-pixel too narrow, so a cell
+  # wraps and the table grows taller than the measured height, spilling the
+  # PDF onto a second page (platform-dependent: seen on macOS, not Linux). Add
+  # 1px so the body is never narrower than the content and never re-wraps.
+  d[1L] = d[1L] + 1L
+  d
 }
 
 #' Export an lt table to a file
@@ -431,9 +438,7 @@ lt_export = function(
   }
   if (crop && is_pdf) {
     # @page size drives the PDF page box exactly; no image post-processing.
-    # scrollHeight is integer-floored; add 1px to absorb sub-pixel font
-    # metrics that differ by platform (e.g. macOS San Francisco vs Linux).
-    style = sprintf('<style>@page{size:%dpx %dpx;margin:0}%s</style>', w, h + 1L, layout)
+    style = sprintf('<style>@page{size:%dpx %dpx;margin:0}%s</style>', w, h, layout)
     html = sub('</head>', paste0(style, '</head>'), html, fixed = TRUE)
     with_temp_html(html, function(f)
       xfun::browser_print(f, output, browser = browser, ...))

--- a/R/render.R
+++ b/R/render.R
@@ -431,7 +431,9 @@ lt_export = function(
   }
   if (crop && is_pdf) {
     # @page size drives the PDF page box exactly; no image post-processing.
-    style = sprintf('<style>@page{size:%dpx %dpx;margin:0}%s</style>', w, h, layout)
+    # scrollHeight is integer-floored; add 1px to absorb sub-pixel font
+    # metrics that differ by platform (e.g. macOS San Francisco vs Linux).
+    style = sprintf('<style>@page{size:%dpx %dpx;margin:0}%s</style>', w, h + 1L, layout)
     html = sub('</head>', paste0(style, '</head>'), html, fixed = TRUE)
     with_temp_html(html, function(f)
       xfun::browser_print(f, output, browser = browser, ...))

--- a/tests/test-ci/test-js.R
+++ b/tests/test-ci/test-js.R
@@ -281,6 +281,22 @@ if (has_browser()) assert("lt_export() crops a large table to one PDF page", {
   (pdf_pages(pdf) %==% 1L)
 })
 
+# A wide table must crop to one page too. scrollWidth is the floor of the
+# table's fractional natural width; pinning the body to that floored width
+# used to leave it a sub-pixel too narrow, wrapping a cell and growing the
+# table past the measured height, so the PDF spilled onto a second page
+# (seen on macOS, not Linux). lt_measure() now rounds the width up by 1px.
+if (has_browser()) assert("lt_export() crops a wide table to one PDF page", {
+  # Many columns with long labels give the table a fractional natural width.
+  x = lt(as.data.frame(matrix(
+    1:32, 4, 8, dimnames = list(NULL, paste0("a_long_column_label_", 1:8))
+  )))
+  pdf = tempfile(fileext = ".pdf")
+  on.exit(unlink(pdf), add = TRUE)
+  lt_export(x, pdf)
+  (pdf_pages(pdf) %==% 1L)
+})
+
 if (has_browser() && xfun::loadable("magick"))
   assert("lt_export() crops PNG tightly to the table size", {
     x = lt(head(mtcars))


### PR DESCRIPTION
`lt_export()` to PDF produces a two-page file on macOS GHA runners
(e.g. `examples/01-lt.pdf`), though it is a single page on Linux. The
1px `@page` height buffer (a972a61) did not resolve it.

This PR temporarily replaces the site build with a debug script
(`debug-pdf.R`) that runs on `macos-latest` to capture the measured
screen-media size vs the print-media height, page counts across several
`@page` height buffers, and the resulting MediaBox. Once the root cause
is pinned down, the fix will replace the debug scaffolding.

**Not ready for merge** — debug scaffolding present.

🤖 Generated with [Claude Code](https://claude.com/claude-code)