### PR TITLE
Support predicate formulas in column selection

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lt
 Type: Package
 Title: Lightweight Tables via JSON Specs and JavaScript
-Version: 0.4.1
+Version: 0.4.2
 Authors@R: person('Yihui', 'Xie', email = 'xie@yihui.name', role = c('aut', 'cre', 'cph'),
     comment = c(ORCID = '0000-0003-0645-5666', URL = 'https://yihui.org'))
 Description: A lightweight grammar of tables. Build a table by declaring a JSON

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: lt
 Type: Package
 Title: Lightweight Tables via JSON Specs and JavaScript
-Version: 0.3.5
+Version: 0.4.1
 Authors@R: person('Yihui', 'Xie', email = 'xie@yihui.name', role = c('aut', 'cre', 'cph'),
     comment = c(ORCID = '0000-0003-0645-5666', URL = 'https://yihui.org'))
 Description: A lightweight grammar of tables. Build a table by declaring a JSON

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 - Column selection now accepts predicate formulas: a one-sided formula whose right-hand side references the pronoun `.` (the character vector of column names) is evaluated as a predicate, and a logical result selects the matching names, e.g., `lt_spanner(x, "Time", columns = ~ endsWith(., "_time"))` or `lt_format(x, ~ grepl("_prob$", .), decimals = 2)`. A character result (e.g., `~ grep("_x$", ., value = TRUE)`) is used as-is. Bare-name formulas (e.g., `~ a + b`) continue to work unchanged. This applies to all functions that select columns.
 
+- `lt_label()` now also accepts a single named list or named character vector mapping column names to labels (e.g., `lt_label(x, c(mpg = "Miles/Gallon", cyl = "Cylinders"))`), which is convenient when labels are computed programmatically. Named arguments (e.g., `lt_label(x, mpg = "Miles/Gallon")`) continue to work.
+
 # CHANGES IN lt VERSION 0.4
 
 - `lt_format()` gained a `sig_digits` argument to format numbers to a fixed number of significant digits (e.g., `lt_format(x, ~col, sig_digits = 3)`), which is useful for columns spanning several orders of magnitude. It is mutually exclusive with `decimals`.

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# CHANGES IN lt VERSION 0.4.1
+
+- Column selection now accepts predicate formulas: a one-sided formula whose right-hand side references the pronoun `.` (the character vector of column names) is evaluated as a predicate, and a logical result selects the matching names, e.g., `lt_spanner(x, "Time", columns = ~ endsWith(., "_time"))` or `lt_format(x, ~ grepl("_prob$", .), decimals = 2)`. A character result (e.g., `~ grep("_x$", ., value = TRUE)`) is used as-is. Bare-name formulas (e.g., `~ a + b`) continue to work unchanged. This applies to all functions that select columns.
+
 # CHANGES IN lt VERSION 0.4
 
 - `lt_format()` gained a `sig_digits` argument to format numbers to a fixed number of significant digits (e.g., `lt_format(x, ~col, sig_digits = 3)`), which is useful for columns spanning several orders of magnitude. It is mutually exclusive with `decimals`.

--- a/R/lt.R
+++ b/R/lt.R
@@ -84,11 +84,25 @@ add_op = function(x, type, ...) {
 
 camel2dash = function(x) gsub('([A-Z])', '-\\L\\1', x, perl = TRUE)
 
-# Resolve a column selection to column names. `cols` may be a one-sided
-# formula (RHS variable names extracted), a character vector, or integer
-# positions (resolved against `names(data)` when `data` is supplied).
+# Resolve a column selection to column names. `cols` may be:
+# - a one-sided formula; if its right-hand side references the pronoun `.`
+#   (the character vector of column names), it is evaluated as a predicate and
+#   a logical result selects the matching names (a character result is used
+#   as-is), e.g. `~ endsWith(., '_time')` or `~ grep('_x$', ., value = TRUE)`;
+#   otherwise the bare variable names on the RHS are taken, e.g. `~ a + b`;
+# - a character vector of column names;
+# - integer positions (resolved against `names(data)` when `data` is supplied).
 f_cols = function(cols, data = NULL) {
-  if (inherits(cols, 'formula')) cols = all.vars(cols[[length(cols)]])
+  if (inherits(cols, 'formula')) {
+    rhs = cols[[length(cols)]]
+    # predicate mode: `.` is bound to the column names
+    if ('.' %in% all.vars(rhs)) {
+      nms = names(data)
+      val = eval(rhs, list(. = nms), environment(cols))
+      return(if (is.logical(val)) nms[val] else val)
+    }
+    cols = all.vars(rhs)
+  }
   if (is.numeric(cols) && !is.null(data)) cols = names(data)[cols]
   cols
 }

--- a/R/tab.R
+++ b/R/tab.R
@@ -28,7 +28,8 @@ lt_header = function(x, title = NULL, subtitle = NULL) {
 #'   two-sided formula `Label ~ col1 + col2` providing both the label (LHS)
 #'   and columns (RHS). When missing, spanners are inferred from column names.
 #' @param columns Columns to span: character names, integer positions, or a
-#'   one-sided formula. When missing, inferred from column names.
+#'   one-sided formula (predicate formulas such as `~ endsWith(., "_time")` are
+#'   also allowed; see [lt_align()]). When missing, inferred from column names.
 #' @param sep Separator pattern for auto-inference (default `"[._]"`).
 #' @note The columns must be contiguous in the body of the table.
 #' @return `x` with the spanner recorded.
@@ -120,8 +121,9 @@ lt_group = function(x, ..., sep = 'auto', sort = TRUE) {
 #' @param where One of `'title'`, `'subtitle'`, `'column'`, `'spanner'`,
 #'   `'group'`, or `'body'`.
 #' @param columns Character names, integer positions, or a one-sided formula
-#'   (for `'column'` or `'body'`). For `'group'` with `match = "starts_with"`,
-#'   a single prefix string.
+#'   (for `'column'` or `'body'`); predicate formulas such as
+#'   `~ endsWith(., "_time")` are also allowed (see [lt_align()]). For
+#'   `'group'` with `match = "starts_with"`, a single prefix string.
 #' @param rows Integer vector of 1-based row indices (for `'body'`; `NULL`
 #'   means all rows).
 #' @param match For `where = "group"`: one of `"exact"` (default),
@@ -201,7 +203,11 @@ lt_note = function(x, text) {
 #'
 #' @param x An [lt()] object.
 #' @param columns Columns to select: a character vector of column names,
-#'   integer positions, or a one-sided formula.
+#'   integer positions, or a one-sided formula. A formula whose right-hand side
+#'   references the pronoun `.` (the character vector of column names) is
+#'   evaluated as a predicate, e.g. `~ endsWith(., "_time")` selects all columns
+#'   whose names end with `_time`; otherwise the bare names on the right-hand
+#'   side are used, e.g. `~ x + y`.
 #' @param align One of `"left"`, `"center"`, or `"right"`.
 #' @return `x` with the alignment recorded.
 #' @export
@@ -338,8 +344,9 @@ lt_label = function(x, ...) {
 #'
 #' @inheritParams lt_align
 #' @param columns Columns whose cells are raw HTML: character names, integer
-#'   positions, or a one-sided formula. If missing, all columns are treated as
-#'   raw HTML.
+#'   positions, or a one-sided formula (predicate formulas such as
+#'   `~ endsWith(., "_time")` are also allowed; see [lt_align()]). If missing,
+#'   all columns are treated as raw HTML.
 #' @return `x` with the raw-HTML columns recorded.
 #' @export
 #' @examples
@@ -359,8 +366,9 @@ lt_html = function(x, columns) {
 #' Replace `NA`, zero, or small values with display text.
 #'
 #' @inheritParams lt_align
-#' @param columns Character names, integer positions, a one-sided formula, or
-#'   `NULL` for all.
+#' @param columns Character names, integer positions, a one-sided formula
+#'   (predicate formulas such as `~ endsWith(., "_time")` are also allowed; see
+#'   [lt_align()]), or `NULL` for all.
 #' @param missing Replacement for `NA` cells in these columns (e.g.,
 #'   `"n/a"`). `NULL` (default) leaves them to the table-wide default, which
 #'   is an em dash (`—`); see the `lt.missing` global option in [lt()].
@@ -404,7 +412,9 @@ lt_indent = function(x, rows, level = 1) {
 #' a pattern. Source columns (all except the first) are hidden by default.
 #'
 #' @inheritParams lt_align
-#' @param columns Character names, integer positions, or a one-sided formula.
+#' @param columns Character names, integer positions, or a one-sided formula
+#'   (predicate formulas such as `~ endsWith(., "_time")` are also allowed; see
+#'   [lt_align()]).
 #'   The first column is the target (receives merged content); the rest are
 #'   sources.
 #' @param pattern A glue-style template using `\{1\}`, `\{2\}`, etc. to refer
@@ -432,8 +442,9 @@ lt_merge = function(x, columns, pattern = NULL, hide = TRUE) {
 #' values (evaluated in JavaScript).
 #'
 #' @inheritParams lt_align
-#' @param columns Character names, integer positions, a one-sided formula, or
-#'   `NULL` for all.
+#' @param columns Character names, integer positions, a one-sided formula
+#'   (predicate formulas such as `~ endsWith(., "_time")` are also allowed; see
+#'   [lt_align()]), or `NULL` for all.
 #' @param rows Integer vector of 1-based row indices (or `NULL` for all).
 #' @param test A JavaScript function as a string (e.g., `"v => v < 0"`) that
 #'   receives the raw cell value and returns `true` to apply the style. When

--- a/R/tab.R
+++ b/R/tab.R
@@ -320,15 +320,24 @@ lt_date = function(x, columns, method = NULL, locale = NULL, options = NULL) {
 #'
 #' @inheritParams lt_align
 #' @param ... Named arguments of the form `col_name = "Display Label"`. Wrap a
-#'   label in [I()] to treat it as raw HTML.
+#'   label in [I()] to treat it as raw HTML. Alternatively, pass a single named
+#'   list or named character vector mapping column names to labels, which is
+#'   convenient when the labels are computed programmatically, e.g.
+#'   `lt_label(x, c(mpg = "Miles/Gallon", cyl = "Cylinders"))`.
 #' @return `x` with the column label overrides recorded.
 #' @export
 #' @examples
 #' lt(head(mtcars)) |> lt_label(mpg = "Miles/Gallon", cyl = "Cylinders")
 #' # raw HTML label (wrap in I())
 #' lt(head(mtcars)) |> lt_label(mpg = I("Miles/Gallon<sup>*</sup>"))
+#' # a single named list or vector of labels
+#' lt(head(mtcars)) |> lt_label(c(mpg = "Miles/Gallon", cyl = "Cylinders"))
 lt_label = function(x, ...) {
-  add_op(x, 'label', labels = list(...))
+  labels = list(...)
+  # allow a single named list/vector of labels instead of named `...`
+  if (length(labels) == 1 && is.null(names(labels)) && !is.null(names(labels[[1]])))
+    labels = as.list(labels[[1]])
+  add_op(x, 'label', labels = labels)
 }
 
 

--- a/man/lt_align.Rd
+++ b/man/lt_align.Rd
@@ -10,7 +10,11 @@ lt_align(x, columns, align = c("left", "center", "right"))
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{columns}{Columns to select: a character vector of column names,
-integer positions, or a one-sided formula.}
+integer positions, or a one-sided formula. A formula whose right-hand side
+references the pronoun \code{.} (the character vector of column names) is
+evaluated as a predicate, e.g. \code{~ endsWith(., "_time")} selects all columns
+whose names end with \verb{_time}; otherwise the bare names on the right-hand
+side are used, e.g. \code{~ x + y}.}
 
 \item{align}{One of \code{"left"}, \code{"center"}, or \code{"right"}.}
 }

--- a/man/lt_date.Rd
+++ b/man/lt_date.Rd
@@ -10,7 +10,11 @@ lt_date(x, columns, method = NULL, locale = NULL, options = NULL)
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{columns}{Columns to select: a character vector of column names,
-integer positions, or a one-sided formula.}
+integer positions, or a one-sided formula. A formula whose right-hand side
+references the pronoun \code{.} (the character vector of column names) is
+evaluated as a predicate, e.g. \code{~ endsWith(., "_time")} selects all columns
+whose names end with \verb{_time}; otherwise the bare names on the right-hand
+side are used, e.g. \code{~ x + y}.}
 
 \item{method}{A JS Date method name to call (e.g., \code{"toLocaleDateString"},
 \code{"toISOString"}, \code{"toDateString"}, \code{"toLocaleString"},

--- a/man/lt_footnote.Rd
+++ b/man/lt_footnote.Rd
@@ -15,8 +15,9 @@ lt_footnote(x, text, where, columns = NULL, rows = NULL, match = NULL)
 \code{'group'}, or \code{'body'}.}
 
 \item{columns}{Character names, integer positions, or a one-sided formula
-(for \code{'column'} or \code{'body'}). For \code{'group'} with \code{match = "starts_with"},
-a single prefix string.}
+(for \code{'column'} or \code{'body'}); predicate formulas such as
+\code{~ endsWith(., "_time")} are also allowed (see \code{\link[=lt_align]{lt_align()}}). For
+\code{'group'} with \code{match = "starts_with"}, a single prefix string.}
 
 \item{rows}{Integer vector of 1-based row indices (for \code{'body'}; \code{NULL}
 means all rows).}

--- a/man/lt_format.Rd
+++ b/man/lt_format.Rd
@@ -19,7 +19,11 @@ lt_format(
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{columns}{Columns to select: a character vector of column names,
-integer positions, or a one-sided formula.}
+integer positions, or a one-sided formula. A formula whose right-hand side
+references the pronoun \code{.} (the character vector of column names) is
+evaluated as a predicate, e.g. \code{~ endsWith(., "_time")} selects all columns
+whose names end with \verb{_time}; otherwise the bare names on the right-hand
+side are used, e.g. \code{~ x + y}.}
 
 \item{decimals}{Number of decimal places (default \code{NULL} means no change).}
 

--- a/man/lt_html.Rd
+++ b/man/lt_html.Rd
@@ -10,8 +10,9 @@ lt_html(x, columns)
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{columns}{Columns whose cells are raw HTML: character names, integer
-positions, or a one-sided formula. If missing, all columns are treated as
-raw HTML.}
+positions, or a one-sided formula (predicate formulas such as
+\code{~ endsWith(., "_time")} are also allowed; see \code{\link[=lt_align]{lt_align()}}). If missing,
+all columns are treated as raw HTML.}
 }
 \value{
 \code{x} with the raw-HTML columns recorded.

--- a/man/lt_label.Rd
+++ b/man/lt_label.Rd
@@ -10,7 +10,10 @@ lt_label(x, ...)
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{...}{Named arguments of the form \code{col_name = "Display Label"}. Wrap a
-label in \code{\link[=I]{I()}} to treat it as raw HTML.}
+label in \code{\link[=I]{I()}} to treat it as raw HTML. Alternatively, pass a single named
+list or named character vector mapping column names to labels, which is
+convenient when the labels are computed programmatically, e.g.
+\code{lt_label(x, c(mpg = "Miles/Gallon", cyl = "Cylinders"))}.}
 }
 \value{
 \code{x} with the column label overrides recorded.
@@ -22,4 +25,6 @@ Override column headers without modifying the underlying data frame.
 lt(head(mtcars)) |> lt_label(mpg = "Miles/Gallon", cyl = "Cylinders")
 # raw HTML label (wrap in I())
 lt(head(mtcars)) |> lt_label(mpg = I("Miles/Gallon<sup>*</sup>"))
+# a single named list or vector of labels
+lt(head(mtcars)) |> lt_label(c(mpg = "Miles/Gallon", cyl = "Cylinders"))
 }

--- a/man/lt_merge.Rd
+++ b/man/lt_merge.Rd
@@ -9,7 +9,9 @@ lt_merge(x, columns, pattern = NULL, hide = TRUE)
 \arguments{
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
-\item{columns}{Character names, integer positions, or a one-sided formula.
+\item{columns}{Character names, integer positions, or a one-sided formula
+(predicate formulas such as \code{~ endsWith(., "_time")} are also allowed; see
+\code{\link[=lt_align]{lt_align()}}).
 The first column is the target (receives merged content); the rest are
 sources.}
 

--- a/man/lt_move.Rd
+++ b/man/lt_move.Rd
@@ -10,7 +10,11 @@ lt_move(x, columns, after = NULL)
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
 \item{columns}{Columns to select: a character vector of column names,
-integer positions, or a one-sided formula.}
+integer positions, or a one-sided formula. A formula whose right-hand side
+references the pronoun \code{.} (the character vector of column names) is
+evaluated as a predicate, e.g. \code{~ endsWith(., "_time")} selects all columns
+whose names end with \verb{_time}; otherwise the bare names on the right-hand
+side are used, e.g. \code{~ x + y}.}
 
 \item{after}{Column name or integer position after which to place the
 moved columns. Use \code{NULL} to move to the start.}

--- a/man/lt_spanner.Rd
+++ b/man/lt_spanner.Rd
@@ -14,7 +14,8 @@ two-sided formula \code{Label ~ col1 + col2} providing both the label (LHS)
 and columns (RHS). When missing, spanners are inferred from column names.}
 
 \item{columns}{Columns to span: character names, integer positions, or a
-one-sided formula. When missing, inferred from column names.}
+one-sided formula (predicate formulas such as \code{~ endsWith(., "_time")} are
+also allowed; see \code{\link[=lt_align]{lt_align()}}). When missing, inferred from column names.}
 
 \item{sep}{Separator pattern for auto-inference (default \code{"[._]"}).}
 }

--- a/man/lt_style.Rd
+++ b/man/lt_style.Rd
@@ -20,8 +20,9 @@ lt_style(
 \arguments{
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
-\item{columns}{Character names, integer positions, a one-sided formula, or
-\code{NULL} for all.}
+\item{columns}{Character names, integer positions, a one-sided formula
+(predicate formulas such as \code{~ endsWith(., "_time")} are also allowed; see
+\code{\link[=lt_align]{lt_align()}}), or \code{NULL} for all.}
 
 \item{rows}{Integer vector of 1-based row indices (or \code{NULL} for all).}
 

--- a/man/lt_sub.Rd
+++ b/man/lt_sub.Rd
@@ -16,8 +16,9 @@ lt_sub(
 \arguments{
 \item{x}{An \code{\link[=lt]{lt()}} object.}
 
-\item{columns}{Character names, integer positions, a one-sided formula, or
-\code{NULL} for all.}
+\item{columns}{Character names, integer positions, a one-sided formula
+(predicate formulas such as \code{~ endsWith(., "_time")} are also allowed; see
+\code{\link[=lt_align]{lt_align()}}), or \code{NULL} for all.}
 
 \item{missing}{Replacement for \code{NA} cells in these columns (e.g.,
 \code{"n/a"}). \code{NULL} (default) leaves them to the table-wide default, which

--- a/tests/testit/test-lt.R
+++ b/tests/testit/test-lt.R
@@ -32,6 +32,18 @@ assert("f_cols() extracts variable names from formula", {
   (f_cols(c("a", "b")) %==% c("a", "b"))
 })
 
+assert("f_cols() resolves a predicate formula against column names", {
+  d = data.frame(asy_time = 1, sim_time = 1, asy_n = 1, sim_prob = 1)
+  # logical predicate selects matching names
+  (f_cols(~ endsWith(., "_time"), d) %==% c("asy_time", "sim_time"))
+  (f_cols(~ startsWith(., "asy"), d) %==% c("asy_time", "asy_n"))
+  (f_cols(~ grepl("_prob$", .), d) %==% "sim_prob")
+  # character result is used as-is
+  (f_cols(~ grep("_time$", ., value = TRUE), d) %==% c("asy_time", "sim_time"))
+  # bare-name formula still works (no `.`)
+  (f_cols(~ asy_time + sim_time, d) %==% c("asy_time", "sim_time"))
+})
+
 assert("camel2dash() converts camelCase to dash-case", {
   (camel2dash(c("borderLeft", "backgroundColor", "color")) %==%
     c("border-left", "background-color", "color"))

--- a/tests/testit/test-tab.R
+++ b/tests/testit/test-tab.R
@@ -181,6 +181,14 @@ assert("lt_label() adds label op", {
   (l$ops %==% list(list(type = "label", labels = list(a = "Alpha", b = "Beta"))))
 })
 
+assert("lt_label() accepts a single named list or vector of labels", {
+  expected = list(list(type = "label", labels = list(a = "Alpha", b = "Beta")))
+  (lt_label(x, list(a = "Alpha", b = "Beta"))$ops %==% expected)
+  (lt_label(x, c(a = "Alpha", b = "Beta"))$ops %==% expected)
+  # named `...` still works and is not treated as a single-list argument
+  (lt_label(x, a = "Alpha", b = "Beta")$ops %==% expected)
+})
+
 assert("lt_html() marks columns as raw HTML", {
   h = lt_html(x, ~ a + b)
   (h$html_cols %==% I(c("a", "b")))


### PR DESCRIPTION
## Summary

Two related quality-of-life changes for column handling — no tidyselect, no non-standard evaluation.

### 1. Predicate formulas in column selection

A one-sided formula whose right-hand side references the pronoun `.` (the character vector of column names) is now evaluated as a **predicate** in `f_cols()`:

- a **logical** result selects the matching names, e.g. `~ endsWith(., "_time")`, `~ startsWith(., "asy")`, `~ grepl("_prob$", .)`;
- a **character** result is used as-is, e.g. `~ grep("_x$", ., value = TRUE)`;
- **bare-name** formulas (e.g. `~ a + b`) are unchanged.

Since every column-selecting function funnels through `f_cols()`, this applies uniformly to `lt_spanner()`, `lt_format()`, `lt_footnote()`, `lt_align()`, `lt_html()`, `lt_sub()`, `lt_merge()`, `lt_style()`, and `lt_move()`.

```r
lt_spanner(x, "Time", columns = ~ endsWith(., "_time"))
lt_format(x, ~ grepl("_prob$", .), decimals = 2)
```

### 2. `lt_label()` accepts a single named list or vector

Besides named `...` (`col = "Label"`), `lt_label()` now accepts a single named list or named character vector mapping column names to labels:

```r
lt_label(x, c(mpg = "Miles/Gallon", cyl = "Cylinders"))
```

Convenient when labels are computed programmatically — avoids `do.call(lt_label, c(list(x), labels))`. Named `...` continues to work.

## Motivation

Downstream (simtrial's `lt()` method, replacing gt) needed to span groups of columns like `*_time`, `*_event`, `*_prob`, and to apply programmatically-computed column labels. Previously that meant manual `grep("_time$", names(x), value = TRUE)` per spanner and a `do.call()` splice for labels. Both now read inline while staying pure base R — formulas are ordinary objects, so no symbol capture or masking.

## Changes

- `f_cols()`: predicate-formula branch (pronoun `.` bound to column names).
- `lt_label()`: single named list/vector splice.
- Tests for both; `@param` docs updated (canonical `lt_align()` + pointers in overriding functions; `lt_label` param).
- NEWS entries; regenerated man pages.

Fully backward compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)